### PR TITLE
Fix method name resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ module.exports = function ({types}) {
         if (path.node.id) {
           functionName = path.node.id.name;
         }
+        
+        if (!functionName && path.node && path.node.key && path.node.key.name) {
+          functionName = path.node.key.name;
+        }
 
         (path.get('params') || [])
           .slice()


### PR DESCRIPTION
I kept getting empty string as method name.
It turned out that the name was in `path.node.key.name` instead of `path.node.id`