### PR TITLE
Support `export class` syntax

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ module.exports = function (_ref) {
           (function () {
             var decorators = Object.create(null);
             path.node.body.filter(function (it) {
-              return it.type === 'ClassDeclaration' || it.type === 'ExportDefaultDeclaration' && it.declaration.type === 'ClassDeclaration';
+              return it.type === 'ClassDeclaration' || ["ExportNamedDeclaration", "ExportDefaultDeclaration"].includes(it.type) && it.declaration.type === 'ClassDeclaration';
             }).map(function (it) {
               return it.type === 'ClassDeclaration' ? it : it.declaration;
             }).forEach(function (clazz) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,19 @@ module.exports = function (_ref) {
           (function () {
             var decorators = Object.create(null);
             path.node.body.filter(function (it) {
-              return it.type === 'ClassDeclaration' || ["ExportNamedDeclaration", "ExportDefaultDeclaration"].includes(it.type) && it.declaration.type === 'ClassDeclaration';
+              const { type, declaration } = it;
+
+              switch (type) {
+                case "ClassDeclaration":
+                  return true;
+                
+                case "ExportNamedDeclaration":
+                case "ExportDefaultDeclaration":
+                  return declaration.type === "ClassDeclaration";
+                
+                default:
+                  return false;
+              }
             }).map(function (it) {
               return it.type === 'ClassDeclaration' ? it : it.declaration;
             }).forEach(function (clazz) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ module.exports = function (_ref) {
 
                 case "ExportNamedDeclaration":
                 case "ExportDefaultDeclaration":
-                  return declaration.type === "ClassDeclaration";
+                  return declaration && declaration.type === "ClassDeclaration";
 
                 default:
                   return false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,16 +76,17 @@ module.exports = function (_ref) {
           (function () {
             var decorators = Object.create(null);
             path.node.body.filter(function (it) {
-              const { type, declaration } = it;
+              var type = it.type,
+                  declaration = it.declaration;
 
               switch (type) {
                 case "ClassDeclaration":
                   return true;
-                
+
                 case "ExportNamedDeclaration":
                 case "ExportDefaultDeclaration":
                   return declaration.type === "ClassDeclaration";
-                
+
                 default:
                   return false;
               }

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ module.exports = function ({ types }) {
                 
                 case "ExportNamedDeclaration":
                 case "ExportDefaultDeclaration":
-                  return declaration.type === "ClassDeclaration";
+                  return declaration && declaration.type === "ClassDeclaration";
                 
                 default:
                   return false;

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,21 @@ module.exports = function ({ types }) {
           const decorators = Object.create(null);
 
           path.node.body
-            .filter(it => it.type === 'ClassDeclaration' || (it.type === 'ExportDefaultDeclaration' && it.declaration.type === 'ClassDeclaration'))
+            .filter(it => {
+              const { type, declaration } = it;
+              
+              switch (type) {
+                case "ClassDeclaration":
+                  return true;
+                
+                case "ExportNamedDeclaration":
+                case "ExportDefaultDeclaration":
+                  return declaration.type === "ClassDeclaration";
+                
+                default:
+                  return false;
+              }
+            })
             .map(it => {
               return it.type === 'ClassDeclaration' ? it : it.declaration;
             })

--- a/test/src/ts/Greeter.ts
+++ b/test/src/ts/Greeter.ts
@@ -2,7 +2,7 @@ import {validate, required, optional, Inject, Factory} from '../decorators'
 import Sentinel, {Counter} from './Sentinel'
 
 @Factory
-class Greeter {
+export class Greeter {
 
   private counter: Counter = this.sentinel.counter;
 

--- a/test/src/ts/Greeter.ts
+++ b/test/src/ts/Greeter.ts
@@ -42,3 +42,9 @@ export class Greeter {
 }
 
 export default Greeter;
+
+function myFunctionToBeExported() {}
+
+export {
+  myFunctionToBeExported
+}


### PR DESCRIPTION
This PR adds support for the `export class` syntax.
It achieves this by not only acting on `ExportDefaultDeclaration`, but also on `ExportNamedDeclaration` nodes.

This PR is divided into three different commits: Test, Fix, Cleanup; which should make it easier to review ^^

PS: Great plugin! It really helps me out on my journey to integrate Next.js and NestJS, so thanks for creating it @WarnerHooh ! :)